### PR TITLE
Fix-up with patched orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: '2.1'
 orbs:
-  node-publisher: lbalmaceda/node-publisher@dev:9b37b36
+  node-publisher: lbalmaceda/node-publisher@dev:d1b8cd7
 workflows:
   build:
     jobs:


### PR DESCRIPTION
The orb version used in the last PR was not picking up the environment variable for publishing to NPM. This version is patched to succeed. :) 