### PR TITLE
[ignore] Fixup Orb version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: '2.1'
 orbs:
-  ship: lbalmaceda/node-publisher@dev:4ac4806
+  ship: lbalmaceda/node-publisher@dev:49dd070
 jobs:
   test:
     executor: ship/node


### PR DESCRIPTION
The previous orb had an issue with the URL path and made the build fail. This should version should be fixed.