### PR TITLE
Release 0.0.7 (with GH tags & releases)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,3 +18,7 @@ workflows:
           context:
             - publish-npm
             - publish-gh
+          filters:
+            branches:
+              only:
+                - master

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luchonpm/tmp-sdk-release-poc",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Temp SDK release project",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This release includes the latest version of the orb, which will make a GH tag and release using the version from the `package.json` file. If this GH Tag already exists, it will skip creating the release.

Because the branch used here doesn't match our expected format of "release/{version name with or without prefix}", then the GH Release that will be created will not have a specific description, using the target commit's message.